### PR TITLE
Rename _config.yml to config.yml

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,1 +1,0 @@
-theme: jekyll-theme-cayman

--- a/config.yml
+++ b/config.yml
@@ -1,0 +1,1 @@
+theme: jekyll-theme-cayman


### PR DESCRIPTION
Rename `_config.yml` to `config.yml` due to this error (Ubuntu):
> Cannot load extension with file or directory name `_config.yml`. Filenames starting with `_` are reserved for use by the system.